### PR TITLE
Fix unable to delete extension on deleted db

### DIFF
--- a/apis/postgresql/v1alpha1/extension_types.go
+++ b/apis/postgresql/v1alpha1/extension_types.go
@@ -29,10 +29,10 @@ import (
 
 // ExtensionParameters are the configurable fields of a Extension.
 type ExtensionParameters struct {
-	// Extension name to be installed
+	// Extension name to be installed.
 	Extension string `json:"extension"`
 
-	// Extension Version to be installed
+	// Version of the extension to be installed.
 	// +immutable
 	// +optional
 	Version *string `json:"version,omitempty"`
@@ -69,10 +69,11 @@ type ExtensionStatus struct {
 
 // +kubebuilder:object:root=true
 
-// A Extension represents the declarative state of a PostgreSQL Extension.
+// An Extension represents the declarative state of a PostgreSQL Extension.
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
+// +kubebuilder:printcolumn:name="DATABASE",type="string",JSONPath=".spec.forProvider.database"
 // +kubebuilder:printcolumn:name="EXTENSION",type="string",JSONPath=".spec.forProvider.extension"
 // +kubebuilder:printcolumn:name="VERSION",type="string",JSONPath=".spec.forProvider.version"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"

--- a/package/crds/postgresql.sql.crossplane.io_extensions.yaml
+++ b/package/crds/postgresql.sql.crossplane.io_extensions.yaml
@@ -25,6 +25,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Synced')].status
       name: SYNCED
       type: string
+    - jsonPath: .spec.forProvider.database
+      name: DATABASE
+      type: string
     - jsonPath: .spec.forProvider.extension
       name: EXTENSION
       type: string
@@ -37,7 +40,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: A Extension represents the declarative state of a PostgreSQL Extension.
+        description: An Extension represents the declarative state of a PostgreSQL Extension.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -84,13 +87,13 @@ spec:
                         type: object
                     type: object
                   extension:
-                    description: Extension name to be installed
+                    description: Extension name to be installed.
                     type: string
                   schema:
                     description: Schema for extension install.
                     type: string
                   version:
-                    description: Extension Version to be installed
+                    description: Version of the extension to be installed.
                     type: string
                 required:
                 - extension

--- a/pkg/controller/postgresql/extension/reconciler_test.go
+++ b/pkg/controller/postgresql/extension/reconciler_test.go
@@ -163,37 +163,6 @@ func TestConnect(t *testing.T) {
 			},
 			want: errors.Wrap(errBoom, errGetSecret),
 		},
-		"SuccessDBSelector": {
-			reason: "No error should be returned when DB Selector is provided",
-			fields: fields{
-				kube: &test.MockClient{
-					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
-						switch o := obj.(type) {
-						case *v1alpha1.ProviderConfig:
-							o.Spec.Credentials.ConnectionSecretRef = &xpv1.SecretReference{}
-						case *corev1.Secret:
-							return nil
-						}
-						return nil
-					}),
-				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
-			},
-			args: args{
-				mg: &v1alpha1.Extension{
-					Spec: v1alpha1.ExtensionSpec{
-						ForProvider: v1alpha1.ExtensionParameters{
-							DatabaseRef:      &xpv1.Reference{},
-							DatabaseSelector: &xpv1.Selector{},
-						},
-						ResourceSpec: xpv1.ResourceSpec{
-							ProviderConfigReference: &xpv1.Reference{},
-						},
-					},
-				},
-			},
-			want: errors.New(errDBRefUnresolved),
-		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
If an Extension was created on a database reference that was then
deleted, and a user tried to then delete the extension, it would sit in
an eternal observation error loop. Observe now checks for an 'invalid
catalog error' as returned from lib/pq to detect this, and reports a
nonexistent resource if the database itself has been deleted.

Signed-off-by: Ben Agricola <bagricola@squiz.co.uk>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
